### PR TITLE
Drive clock pin as an output insted of a weak input

### DIFF
--- a/Arduino/ic_tester/test_functions.ino
+++ b/Arduino/ic_tester/test_functions.ino
@@ -42,9 +42,8 @@ boolean testCase(String test, int pins)
   if (clkPin != -1)
   {
     //Clock Trigger
-    pinMode(clkPin, INPUT_PULLUP);
+    digitalWrite(clkPin, HIGH);
     delay(10);
-    pinMode(clkPin, OUTPUT);
     digitalWrite(clkPin, LOW);
   }
 


### PR DESCRIPTION
While I was testing some Integrated circuits, I found out that some of them did not work when the "C" signal type was used to drive clock pin. The reason was that the HIGH level generated using `INPUT_PULLUP` mode was to weak and the IO did not detected it as a HIGH level. This pull request resoved it.

Was there any specific reason to drive the high level using internal pull up in the input mode?